### PR TITLE
fix: add 10MB limit to replace_file_content

### DIFF
--- a/tools/src/aden_tools/tools/file_system_toolkits/replace_file_content/replace_file_content.py
+++ b/tools/src/aden_tools/tools/file_system_toolkits/replace_file_content/replace_file_content.py
@@ -10,7 +10,12 @@ def register_tools(mcp: FastMCP) -> None:
 
     @mcp.tool()
     def replace_file_content(
-        path: str, target: str, replacement: str, workspace_id: str, agent_id: str, session_id: str
+        path: str,
+        target: str,
+        replacement: str,
+        workspace_id: str,
+        agent_id: str,
+        session_id: str,
     ) -> dict:
         """
         Purpose
@@ -41,6 +46,14 @@ def register_tools(mcp: FastMCP) -> None:
             secure_path = get_secure_path(path, workspace_id, agent_id, session_id)
             if not os.path.exists(secure_path):
                 return {"error": f"File not found at {path}"}
+
+            # Check file size before reading to prevent OOM
+            max_size = 10 * 1024 * 1024  # 10MB
+            file_size = os.path.getsize(secure_path)
+            if file_size > max_size:
+                return {
+                    "error": f"File too large: {file_size} bytes. Max allowed is {max_size} bytes."
+                }
 
             with open(secure_path, encoding="utf-8") as f:
                 content = f.read()


### PR DESCRIPTION
## Summary
- Prevents OOM by adding a 10MB limit to `replace_file_content`.
- Fixes #9

## Validation Evidence
Verified locally.