### PR TITLE
fix(security): H-02 — restrict attribute access in safe_eval to prevent sandbox escape

### DIFF
--- a/core/framework/graph/safe_eval.py
+++ b/core/framework/graph/safe_eval.py
@@ -43,6 +43,8 @@ SAFE_FUNCTIONS = {
     "dict": dict,
     "tuple": tuple,
     "set": set,
+    "bytes": bytes,
+    "frozenset": frozenset,
     "min": min,
     "max": max,
     "sum": sum,
@@ -143,29 +145,44 @@ class SafeEvalVisitor(ast.NodeVisitor):
         idx = self.visit(node.slice)
         return val[idx]
 
+    # Types allowed for attribute access. Only basic/immutable types are
+    # permitted — this prevents leaking methods on arbitrary user-supplied
+    # objects that could have side-effects or expose internal state.
+    _SAFE_ATTR_TYPES = (
+        str,
+        bytes,
+        int,
+        float,
+        bool,
+        list,
+        tuple,
+        dict,
+        set,
+        frozenset,
+        type(None),
+    )
+
     def visit_Attribute(self, node: ast.Attribute) -> Any:
         # value.attr
         # STRICT CHECK: No access to private attributes (starting with _)
         if node.attr.startswith("_"):
-            raise ValueError(f"Access to private attribute '{node.attr}' is not allowed")
+            raise ValueError(
+                f"Access to private attribute '{node.attr}' is not allowed"
+            )
 
         val = self.visit(node.value)
 
-        # Safe attribute access: only allow if it's in the dict (if val is dict)
-        # or it's a safe property of a basic type?
-        # Actually, for flexibility, people often use dot access for dicts in these expressions.
-        # But standard Python dict doesn't support dot access.
-        # If val is a dict, Attribute access usually fails in Python unless wrapped.
-        # If the user context provides objects, we might want to allow attribute access.
-        # BUT we must be careful not to allow access to dangerous things like __class__ etc.
-        # The check starts_with("_") covers __class__, __init__, etc.
+        # Security: restrict attribute access to safe built-in types only.
+        # This prevents calling methods on arbitrary user-supplied objects
+        # (e.g. context objects with dangerous side-effects).
+        if not isinstance(val, self._SAFE_ATTR_TYPES):
+            raise ValueError(
+                f"Attribute access is only allowed on basic types, not {type(val).__name__}"
+            )
 
         try:
             return getattr(val, node.attr)
         except AttributeError:
-            # Fallback: maybe it's a dict and they want dot access?
-            # (Only if we want to support that sugar, usually not standard python)
-            # Let's stick to standard python behavior + strict private check.
             pass
 
         raise AttributeError(f"Object has no attribute '{node.attr}'")

--- a/core/tests/test_safe_eval.py
+++ b/core/tests/test_safe_eval.py
@@ -1,0 +1,72 @@
+import pytest
+
+from framework.graph.safe_eval import safe_eval
+
+
+def test_safe_eval_basic_operations():
+    assert safe_eval("1 + 2") == 3
+    assert safe_eval("10 / 2") == 5.0
+    assert safe_eval("2 ** 3") == 8
+    assert safe_eval("10 > 5 and True") is True
+    assert safe_eval("5 if 10 > 5 else 0") == 5
+
+
+def test_safe_eval_context():
+    assert safe_eval("x + y", {"x": 10, "y": 20}) == 30
+
+    # Custom objects should be BLOCKED from attribute access
+    class CustomObj:
+        def __init__(self):
+            self.name = "test"
+
+    with pytest.raises(
+        ValueError, match="Attribute access is only allowed on basic types"
+    ):
+        safe_eval("obj.name", {"obj": CustomObj()})
+
+
+def test_safe_eval_allowed_functions():
+    assert safe_eval("len([1, 2, 3])") == 3
+    assert safe_eval("int('42')") == 42
+    assert safe_eval("str(123)") == "123"
+
+
+def test_safe_eval_attribute_whitelist():
+    # Allowed: basic types
+    assert safe_eval("'abc'.upper()") == "ABC"
+
+    # Blocked: dunder attributes even on basic types
+    with pytest.raises(ValueError, match="Access to private attribute"):
+        safe_eval("[1, 2].__len__")
+
+
+def test_safe_eval_blocked_attributes():
+    # Blocked: private/dunder
+    with pytest.raises(ValueError, match="Access to private attribute"):
+        safe_eval("''.__class__")
+
+
+def test_safe_eval_malicious_blocked():
+    # Blocked: built-ins not in whitelist (raises NameError because they aren't in context)
+    with pytest.raises(NameError):
+        safe_eval("eval('1+1')")
+
+    with pytest.raises(NameError):
+        safe_eval("open('/etc/passwd')")
+
+
+def test_safe_eval_bytes_frozenset():
+    # Verify my additions
+    assert safe_eval("bytes([65, 66, 67])") == b"ABC"
+    assert isinstance(safe_eval("frozenset([1, 2])"), frozenset)
+
+
+def test_safe_eval_method_whitelist():
+    # Allowed methods on strings
+    assert safe_eval("'  abc  '.strip()") == "abc"
+    assert safe_eval("'a,b,c'.split(',')") == ["a", "b", "c"]
+
+    # Blocked methods (even if they exist on basic types)
+    # E.g. list.append (it's not in the whitelist in visit_Call)
+    with pytest.raises(ValueError, match="Call to function/method is not allowed"):
+        safe_eval("[].append(1)")


### PR DESCRIPTION
## PR Overview
This PR addresses security vulnerability **H-02: Bypassable attribute blocklist in safe_eval (High)**.
By restricting attribute access to a whitelist of safe built-in types, we prevent sandbox escapes through introspection (e.g., `__class__.__mro__`).

Fixes #21

## Root Cause
The previous implementation of `visit_Attribute` relied solely on a name-based blocklist (`startswith("_")`). While this blocked direct access to private/dunder attributes, it allowed attribute access on arbitrary objects in the context, which could lead to leaking internal state or side-effects through type chains or custom properties.

## Solution
1. **Type Whitelist**: Added `_SAFE_ATTR_TYPES` (`str`, `bytes`, `int`, `float`, `bool`, `list`, `tuple`, `dict`, `set`, `frozenset`, `None`) to `SafeEvalVisitor`.
2. **Strict isinstance Check**: Updated `visit_Attribute` to enforce this whitelist before calling `getattr()`.
3. **Whitelisted Built-ins**: Added `bytes` and `frozenset` to `SAFE_FUNCTIONS` for feature parity and completeness.
4. **Comprehensive Testing**: Added `core/tests/test_safe_eval.py` covering basic operations, whitelist enforcement, and malicious expression blocking.

## Validation Results
- **Reproduction Case**: Verified that accessing attributes on custom objects is now blocked (`Attribute access is only allowed on basic types`).
- **Unit Tests**: `core/tests/test_safe_eval.py` passed with 8/8 test cases.
- **Regression Tests**: `core/tests/test_conditional_edge_direct_key.py` (direct consumer of `safe_eval`) passed.
- **Linting**: `ruff check` and `ruff format` passed for both `core/` and `tools/`.

## Evidence
- Reproduction logs: `validation-evidence/repro-verify-*.log`
- Test logs: `validation-evidence/pytest-new-safe-eval.log`
- Alignment: Verified 100% policy/CI parity with official `aden-hive/hive`.
