### PR TITLE
test: add unit tests for agent lifecycle and graph management tools

### DIFF
--- a/core/framework/tools/queen_lifecycle_tools.py
+++ b/core/framework/tools/queen_lifecycle_tools.py
@@ -397,7 +397,7 @@ def register_queen_lifecycle_tools(
 
         # Find an active node that can accept injected input
         for stream in reg.streams.values():
-            injectable = stream.get_injectable_nodes()
+            injectable = await stream.get_injectable_nodes()
             if injectable:
                 target_node_id = injectable[0]["node_id"]
                 ok = await stream.inject_input(target_node_id, content)

--- a/core/tests/test_queen_lifecycle_tools.py
+++ b/core/tests/test_queen_lifecycle_tools.py
@@ -1,0 +1,116 @@
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from framework.tools.queen_lifecycle_tools import (
+    register_queen_lifecycle_tools,
+)
+
+
+@pytest.fixture
+def mock_registry():
+    class MockRegistry:
+        def __init__(self):
+            self.tools = {}
+
+        def register(self, name, tool, impl):
+            self.tools[name] = impl
+
+    return MockRegistry()
+
+
+@pytest.fixture
+def mock_runtime():
+    runtime = MagicMock()
+    runtime.graph_id = "worker_1"
+    runtime.goal.name = "Test Goal"
+    runtime.trigger = AsyncMock(return_value="exec_123")
+    runtime.get_graph_registration = MagicMock()
+    runtime._get_primary_session_state = MagicMock(return_value={})
+    return runtime
+
+
+@pytest.fixture
+def mock_session(mock_runtime):
+    session = MagicMock()
+    session.worker_runtime = mock_runtime
+    return session
+
+
+def test_register_queen_lifecycle_tools(mock_registry, mock_session):
+    count = register_queen_lifecycle_tools(mock_registry, session=mock_session)
+    assert count >= 4
+    assert "start_worker" in mock_registry.tools
+    assert "stop_worker" in mock_registry.tools
+    assert "get_worker_status" in mock_registry.tools
+    assert "inject_worker_message" in mock_registry.tools
+
+
+@pytest.mark.asyncio
+async def test_start_worker_success(mock_registry, mock_session, mock_runtime):
+    register_queen_lifecycle_tools(mock_registry, session=mock_session)
+    start_worker = mock_registry.tools["start_worker"]
+
+    with patch(
+        "framework.tools.queen_lifecycle_tools.validate_agent_credentials",
+        return_value=None,
+    ):
+        res_str = await start_worker({"task": "Do something"})
+        res = json.loads(res_str)
+        assert res["status"] == "started"
+        assert res["execution_id"] == "exec_123"
+        mock_runtime.trigger.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_stop_worker_success(mock_registry, mock_session, mock_runtime):
+    register_queen_lifecycle_tools(mock_registry, session=mock_session)
+    stop_worker = mock_registry.tools["stop_worker"]
+
+    mock_reg = MagicMock()
+    mock_stream = AsyncMock()
+    mock_stream.active_execution_ids = ["exec_123"]
+    mock_stream.cancel_execution = AsyncMock(return_value=True)
+    mock_reg.streams = {"default": mock_stream}
+    mock_runtime.get_graph_registration.return_value = mock_reg
+
+    res_str = await stop_worker({})
+    res = json.loads(res_str)
+    assert res["status"] == "stopped"
+    assert "exec_123" in res["cancelled"]
+
+
+@pytest.mark.asyncio
+async def test_get_worker_status(mock_registry, mock_session, mock_runtime):
+    register_queen_lifecycle_tools(mock_registry, session=mock_session)
+    get_status = mock_registry.tools["get_worker_status"]
+
+    mock_reg = MagicMock()
+    mock_stream = MagicMock()
+    mock_stream.active_execution_ids = ["exec_123"]
+    mock_reg.streams = {"default": mock_stream}
+    mock_runtime.get_graph_registration.return_value = mock_reg
+
+    res_str = await get_status({})
+    res = json.loads(res_str)
+    assert res["status"] == "running"
+    assert res["worker_graph_id"] == "worker_1"
+
+
+@pytest.mark.asyncio
+async def test_inject_worker_message(mock_registry, mock_session, mock_runtime):
+    register_queen_lifecycle_tools(mock_registry, session=mock_session)
+    inject = mock_registry.tools["inject_worker_message"]
+
+    mock_reg = MagicMock()
+    mock_stream = AsyncMock()
+    mock_stream.get_injectable_nodes.return_value = [{"node_id": "node1"}]
+    mock_stream.inject_input.return_value = True
+    mock_reg.streams = {"default": mock_stream}
+    mock_runtime.get_graph_registration.return_value = mock_reg
+
+    res_str = await inject({"content": "Hello worker"})
+    res = json.loads(res_str)
+    assert res["status"] == "delivered"
+    assert res["node_id"] == "node1"

--- a/core/tests/test_session_graph_tools.py
+++ b/core/tests/test_session_graph_tools.py
@@ -1,0 +1,109 @@
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from framework.tools.session_graph_tools import register_graph_tools
+
+
+@pytest.fixture
+def mock_registry():
+    class MockRegistry:
+        def __init__(self):
+            self.tools = {}
+
+        def register(self, name, tool, impl):
+            self.tools[name] = impl
+
+    return MockRegistry()
+
+
+@pytest.fixture
+def mock_runtime():
+    runtime = MagicMock()
+    runtime.list_graphs = MagicMock(return_value=["primary"])
+    runtime.add_graph = AsyncMock()
+    runtime.remove_graph = AsyncMock()
+    runtime.get_graph_registration = MagicMock()
+    runtime._get_primary_session_state = MagicMock()
+    return runtime
+
+
+def test_register_graph_tools(mock_registry, mock_runtime):
+    count = register_graph_tools(mock_registry, mock_runtime)
+    assert count >= 5
+    assert "load_agent" in mock_registry.tools
+    assert "unload_agent" in mock_registry.tools
+    assert "start_agent" in mock_registry.tools
+    assert "restart_agent" in mock_registry.tools
+    assert "list_agents" in mock_registry.tools
+
+
+@pytest.mark.asyncio
+async def test_load_agent_success(mock_registry, mock_runtime, tmp_path):
+    register_graph_tools(mock_registry, mock_runtime)
+    load_agent = mock_registry.tools["load_agent"]
+
+    agent_dir = tmp_path / "test_agent"
+    agent_dir.mkdir()
+
+    mock_runner = MagicMock()
+    mock_runner.graph.nodes = [MagicMock(id="node1")]
+    mock_runner.graph.entry_node = "node1"
+    mock_runner.graph.async_entry_points = []
+
+    with patch("framework.runner.runner.AgentRunner.load", return_value=mock_runner):
+        res_str = await load_agent({"agent_path": str(agent_dir)})
+        res = json.loads(res_str)
+        assert res["status"] == "loaded"
+        assert res["graph_id"] == "test_agent"
+        mock_runtime.add_graph.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_unload_agent_success(mock_registry, mock_runtime):
+    register_graph_tools(mock_registry, mock_runtime)
+    unload_agent = mock_registry.tools["unload_agent"]
+
+    res_str = await unload_agent({"graph_id": "test_agent"})
+    res = json.loads(res_str)
+    assert res["status"] == "unloaded"
+    mock_runtime.remove_graph.assert_called_once_with("test_agent")
+
+
+@pytest.mark.asyncio
+async def test_start_agent_success(mock_registry, mock_runtime):
+    register_graph_tools(mock_registry, mock_runtime)
+    start_agent = mock_registry.tools["start_agent"]
+
+    mock_reg = MagicMock()
+    mock_stream = AsyncMock()
+    mock_stream.execute.return_value = "exec_123"
+    mock_reg.streams = {"default": mock_stream}
+    mock_runtime.get_graph_registration.return_value = mock_reg
+
+    res_str = await start_agent({"graph_id": "test_agent", "entry_point": "default"})
+    res = json.loads(res_str)
+    assert res["status"] == "triggered"
+    assert res["execution_id"] == "exec_123"
+
+
+@pytest.mark.asyncio
+async def test_list_agents(mock_registry, mock_runtime):
+    register_graph_tools(mock_registry, mock_runtime)
+    list_agents = mock_registry.tools["list_agents"]
+
+    mock_reg = MagicMock()
+    mock_reg.graph.goal.name = "Test Goal"
+    mock_stream = MagicMock()
+    mock_stream.active_execution_ids = ["e1"]
+    mock_reg.streams = {"default": mock_stream}
+
+    mock_runtime.list_graphs.return_value = ["g1"]
+    mock_runtime.get_graph_registration.return_value = mock_reg
+
+    res_str = list_agents({})
+    res = json.loads(res_str)
+    assert "graphs" in res
+    assert len(res["graphs"]) == 1
+    assert res["graphs"][0]["graph_id"] == "g1"


### PR DESCRIPTION
## Summary
Fixes #35 (Port of #5608)

Added unit tests for `session_graph_tools.py` and `queen_lifecycle_tools.py`. 

## Bug Fix
During test development, I discovered and fixed a bug in `queen_lifecycle_tools.py`: the `get_injectable_nodes()` method was being called without `await`, which would have caused a runtime error when injecting messages to a worker.

## Changes
- Created `test_session_graph_tools.py`.
- Created `test_queen_lifecycle_tools.py`.
- Fixed missing `await` in `inject_worker_message`.