### PR TITLE
docs: update outdated path reference in core/README.md

### DIFF
--- a/core/README.md
+++ b/core/README.md
@@ -64,7 +64,7 @@ To use the agent builder with Claude Desktop or other MCP clients, add this to y
     "agent-builder": {
       "command": "python",
       "args": ["-m", "framework.mcp.agent_builder_server"],
-      "cwd": "/path/to/goal-agent"
+      "cwd": "/path/to/hive/core"
     }
   }
 }


### PR DESCRIPTION
## Summary
Fixes #37 (Port of #5628)

Updated the MCP client configuration example in `core/README.md` to reflect the current project name and path structure (`hive/core` instead of `goal-agent`).