### PR TITLE
fix(runtime): use UUID for decision IDs to prevent collisions

### DIFF
--- a/core/framework/runtime/core.py
+++ b/core/framework/runtime/core.py
@@ -89,7 +89,9 @@ class Runtime:
         Returns:
             The run ID
         """
-        run_id = f"run_{datetime.now().strftime('%Y%m%d_%H%M%S')}_{uuid.uuid4().hex[:8]}"
+        run_id = (
+            f"run_{datetime.now().strftime('%Y%m%d_%H%M%S')}_{uuid.uuid4().hex[:8]}"
+        )
         trace_id = uuid.uuid4().hex
         execution_id = uuid.uuid4().hex  # 32 hex, OTel/W3C-aligned for logs
 
@@ -125,7 +127,9 @@ class Runtime:
         if self._current_run is None:
             # Gracefully handle case where run was already ended or never started
             # This can happen during exception handling cascades
-            logger.warning("end_run called but no run in progress (already ended or never started)")
+            logger.warning(
+                "end_run called but no run in progress (already ended or never started)"
+            )
             return
 
         status = RunStatus.COMPLETED if success else RunStatus.FAILED
@@ -207,7 +211,8 @@ class Runtime:
             )
 
         # Create decision
-        decision_id = f"dec_{len(self._current_run.decisions)}"
+        # Use UUID to prevent collisions in concurrent environments
+        decision_id = f"dec_{uuid.uuid4().hex[:8]}"
         decision = Decision(
             id=decision_id,
             node_id=node_id or self._current_node,

--- a/core/tests/test_runtime.py
+++ b/core/tests/test_runtime.py
@@ -71,7 +71,8 @@ class TestDecisionRecording:
             reasoning="More formal",
         )
 
-        assert decision_id == "dec_0"
+        assert decision_id.startswith("dec_")
+        assert len(decision_id) > 5
         assert len(runtime.current_run.decisions) == 1
 
         decision = runtime.current_run.decisions[0]


### PR DESCRIPTION
## Summary
Fixes #39 (Port of #2161)

The `Runtime.decide()` method previously generated decision IDs based on the current list length, which caused collisions in concurrent/multi-threaded environments. 

## Changes
- Changed decision ID generation to use a random 8-char hex string (via `uuid4`).
- Updated `test_runtime.py` to assert the ID format rather than a specific index.