### PR TITLE
feat(ux): align Makefile targets with CI workflow commands to prevent drift

### DIFF
--- a/.hive-ops/reports/alignment-58-20260303-134134.md
+++ b/.hive-ops/reports/alignment-58-20260303-134134.md
@@ -1,0 +1,13 @@
+# Alignment Report for PR 58 (feat(ux): align Makefile targets with CI)
+
+## 1. Policy Delta
+- Local developer UX commands now perfectly match CI pipeline logic.
+
+## 2. CI Delta
+- CI relies on `uv run`, local `make` targets are updated to match it.
+
+## 3. Superset Validation Plan
+- `make check` executes exact CI lint commands without modifying files.
+
+## 4. Evidence
+- Exit code 0 for `make check`. Log saved to `.hive-ops/evidence/`.

--- a/Makefile
+++ b/Makefile
@@ -5,23 +5,21 @@ help: ## Show this help
 		awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2}'
 
 lint: ## Run ruff linter and formatter (with auto-fix)
-	cd core && ruff check --fix .
-	cd tools && ruff check --fix .
-	cd core && ruff format .
-	cd tools && ruff format .
+	uv run --project core ruff check --fix core/ tools/
+	uv run --project core ruff format core/ tools/
 
 format: ## Run ruff formatter
-	cd core && ruff format .
-	cd tools && ruff format .
+	uv run --project core ruff format core/ tools/
 
 check: ## Run all checks without modifying files (CI-safe)
-	cd core && ruff check .
-	cd tools && ruff check .
-	cd core && ruff format --check .
-	cd tools && ruff format --check .
+	uv run --project core ruff check core/
+	uv run --project core ruff check tools/
+	uv run --project core ruff format --check core/
+	uv run --project core ruff format --check tools/
 
-test: ## Run all tests
-	cd core && uv run python -m pytest tests/ -v
+test: ## Run core and tools tests (matches CI)
+	cd core && uv sync && uv run pytest tests/ -v
+	cd tools && uv sync --extra dev && uv run pytest tests/ -v
 
 install-hooks: ## Install pre-commit hooks
 	uv pip install pre-commit


### PR DESCRIPTION
Fixes #58

## Validation Evidence (Mandatory)
- [x] I have provided execution evidence (logs/exit codes) for local checks.
- [x] Unit tests pass
- [x] Lint & Format pass via updated `make check`
- [x] The alignment report confirms no unintended drift.