### PR TITLE
test(tools): add unit tests for security scanners (dns, http headers, ssl/tls)

### DIFF
--- a/tools/tests/tools/test_dns_security_scanner.py
+++ b/tools/tests/tools/test_dns_security_scanner.py
@@ -1,0 +1,142 @@
+"""Tests for DNS Security Scanner tools (FastMCP)."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastmcp import FastMCP
+
+from aden_tools.tools.dns_security_scanner import register_tools
+
+
+@pytest.fixture
+def dns_tools(mcp: FastMCP):
+    """Register DNS tools and return a dict of tool functions."""
+    register_tools(mcp)
+    tools = mcp._tool_manager._tools
+    return {name: tools[name].fn for name in tools}
+
+
+@pytest.fixture
+def scan_fn(dns_tools):
+    return dns_tools["dns_security_scan"]
+
+
+class TestDNSSecurityScan:
+    """Tests for dns_security_scan tool."""
+
+    @patch("dns.resolver.Resolver")
+    def test_dns_security_scan_basic(self, mock_resolver_class, scan_fn):
+        """Test basic DNS security scan with mock records."""
+        mock_resolver = mock_resolver_class.return_value
+
+        # Mock responses for different record types
+        def mock_resolve(qname, rdtype, **kwargs):
+            mock_answer = MagicMock()
+            if rdtype == "TXT":
+                if str(qname).startswith("_dmarc"):
+                    # DMARC record
+                    mock_answer.to_text.return_value = '"v=DMARC1; p=reject;"'
+                else:
+                    # SPF record
+                    mock_answer.to_text.return_value = (
+                        '"v=spf1 include:_spf.google.com -all"'
+                    )
+            elif rdtype == "MX":
+                mock_answer.preference = 10
+                mock_answer.exchange = "mail.example.com"
+            elif rdtype == "DNSKEY":
+                mock_answer.to_text.return_value = "mock-dnskey"
+            elif rdtype == "CAA":
+                mock_answer.to_text.return_value = '0 issue "letsencrypt.org"'
+            elif rdtype == "NS":
+                mock_answer.target = "ns1.example.com"
+            else:
+                import dns.resolver
+
+                raise dns.resolver.NoAnswer()
+
+            return [mock_answer]
+
+        mock_resolver.resolve.side_effect = mock_resolve
+
+        # Mock zone transfer failure (safe default)
+        with patch("dns.zone.from_xfr") as mock_from_xfr:
+            mock_from_xfr.return_value = None
+
+            result = scan_fn(domain="example.com")
+
+        assert "domain" in result
+        assert result["domain"] == "example.com"
+        assert result["spf"]["present"] is True
+        assert result["spf"]["policy"] == "hardfail"
+        assert result["dmarc"]["present"] is True
+        assert result["dmarc"]["policy"] == "reject"
+        assert result["dnssec"]["enabled"] is True
+        assert result["zone_transfer"]["vulnerable"] is False
+        assert "grade_input" in result
+
+    @patch("dns.resolver.Resolver")
+    def test_dns_security_scan_missing_records(self, mock_resolver_class, scan_fn):
+        """Test scan when no records are found."""
+        import dns.resolver
+
+        mock_resolver = mock_resolver_class.return_value
+        mock_resolver.resolve.side_effect = dns.resolver.NoAnswer()
+
+        with patch("dns.zone.from_xfr") as mock_from_xfr:
+            mock_from_xfr.return_value = None
+
+            result = scan_fn(domain="missing.com")
+
+        assert result["spf"]["present"] is False
+        assert result["dmarc"]["present"] is False
+        assert result["dnssec"]["enabled"] is False
+        assert result["mx_records"] == []
+        assert result["caa_records"] == []
+
+    @patch("dns.resolver.Resolver")
+    def test_zone_transfer_vulnerability(self, mock_resolver_class, scan_fn):
+        """Test detection of zone transfer vulnerability."""
+        mock_resolver = mock_resolver_class.return_value
+
+        # Mock NS record
+        ns_answer = MagicMock()
+        ns_answer.target = "ns1.vulnerable.com"
+
+        # Mock resolve to return NS for the domain, and failure for others
+        def mock_resolve(qname, rdtype, **kwargs):
+            if rdtype == "NS":
+                return [ns_answer]
+            import dns.resolver
+
+            raise dns.resolver.NoAnswer()
+
+        mock_resolver.resolve.side_effect = mock_resolve
+
+        # Mock successful AXFR
+        mock_zone = MagicMock()
+        mock_node = MagicMock()
+        mock_zone.nodes = [mock_node, mock_node, mock_node]  # 3 records
+
+        with patch("dns.zone.from_xfr") as mock_from_xfr:
+            mock_from_xfr.return_value = mock_zone
+
+            result = scan_fn(domain="vulnerable.com")
+
+        assert result["zone_transfer"]["vulnerable"] is True
+        assert result["zone_transfer"]["record_count"] == 3
+        assert result["zone_transfer"]["severity"] == "critical"
+
+    @patch("dns.resolver.Resolver")
+    def test_domain_cleaning(self, mock_resolver_class, scan_fn):
+        """Test that domain input is cleaned correctly."""
+        mock_resolver = mock_resolver_class.return_value
+        import dns.resolver
+
+        mock_resolver.resolve.side_effect = dns.resolver.NoAnswer()
+
+        with patch("dns.zone.from_xfr") as mock_from_xfr:
+            mock_from_xfr.return_value = None
+
+            result = scan_fn(domain="https://example.com/path?query=1")
+            assert result["domain"] == "example.com"

--- a/tools/tests/tools/test_http_headers_scanner.py
+++ b/tools/tests/tools/test_http_headers_scanner.py
@@ -1,0 +1,104 @@
+"""Tests for HTTP Headers Scanner tools (FastMCP)."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+from fastmcp import FastMCP
+
+from aden_tools.tools.http_headers_scanner import register_tools
+
+
+@pytest.fixture
+def headers_tools(mcp: FastMCP):
+    """Register HTTP headers tools and return a dict of tool functions."""
+    register_tools(mcp)
+    tools = mcp._tool_manager._tools
+    return {name: tools[name].fn for name in tools}
+
+
+@pytest.fixture
+def scan_fn(headers_tools):
+    return headers_tools["http_headers_scan"]
+
+
+class TestHTTPHeadersScan:
+    """Tests for http_headers_scan tool."""
+
+    @pytest.mark.asyncio
+    async def test_http_headers_scan_basic(self, scan_fn):
+        """Test basic HTTP headers scan with mock response."""
+        mock_headers = {
+            "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+            "Content-Security-Policy": "default-src 'self'",
+            "X-Frame-Options": "DENY",
+            "X-Content-Type-Options": "nosniff",
+            "Referrer-Policy": "no-referrer",
+            "Permissions-Policy": "geolocation=()",
+            "X-XSS-Protection": "1; mode=block",
+        }
+
+        mock_response = MagicMock(spec=httpx.Response)
+        mock_response.headers = httpx.Headers(mock_headers)
+        mock_response.status_code = 200
+        mock_response.url = httpx.URL("https://example.com")
+
+        with patch("httpx.AsyncClient.get", new_callable=AsyncMock) as mock_get:
+            mock_get.return_value = mock_response
+
+            result = await scan_fn(url="example.com")
+
+        assert result["status_code"] == 200
+        assert "Strict-Transport-Security" in result["headers_present"]
+        assert "Content-Security-Policy" in result["headers_present"]
+        assert len(result["headers_missing"]) == 0
+        assert result["grade_input"]["hsts"] is True
+        assert result["grade_input"]["csp"] is True
+
+    @pytest.mark.asyncio
+    async def test_http_headers_scan_missing_headers(self, scan_fn):
+        """Test scan when security headers are missing."""
+        mock_headers = {"Server": "Apache/2.4.41 (Ubuntu)", "X-Powered-By": "PHP/7.4.3"}
+
+        mock_response = MagicMock(spec=httpx.Response)
+        mock_response.headers = httpx.Headers(mock_headers)
+        mock_response.status_code = 200
+        mock_response.url = httpx.URL("https://insecure.com")
+
+        with patch("httpx.AsyncClient.get", new_callable=AsyncMock) as mock_get:
+            mock_get.return_value = mock_response
+
+            result = await scan_fn(url="insecure.com")
+
+        assert len(result["headers_present"]) == 0
+        assert len(result["headers_missing"]) > 0
+        assert len(result["leaky_headers"]) == 2
+        assert result["grade_input"]["hsts"] is False
+        assert result["grade_input"]["no_leaky_headers"] is False
+
+    @pytest.mark.asyncio
+    async def test_http_headers_scan_connection_error(self, scan_fn):
+        """Test scan when connection fails."""
+        with patch("httpx.AsyncClient.get", new_callable=AsyncMock) as mock_get:
+            mock_get.side_effect = httpx.ConnectError("Connection refused")
+
+            result = await scan_fn(url="offline.com")
+
+        assert "error" in result
+        assert "Connection failed" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_url_prefixing(self, scan_fn):
+        """Test that URL is auto-prefixed with https:// if missing."""
+        mock_response = MagicMock(spec=httpx.Response)
+        mock_response.headers = httpx.Headers({})
+        mock_response.status_code = 200
+        mock_response.url = httpx.URL("https://example.com")
+
+        with patch("httpx.AsyncClient.get", new_callable=AsyncMock) as mock_get:
+            mock_get.return_value = mock_response
+
+            await scan_fn(url="example.com")
+            mock_get.assert_called_once()
+            args, _ = mock_get.call_args
+            assert args[0] == "https://example.com"

--- a/tools/tests/tools/test_ssl_tls_scanner.py
+++ b/tools/tests/tools/test_ssl_tls_scanner.py
@@ -1,0 +1,132 @@
+"""Tests for SSL/TLS Scanner tools (FastMCP)."""
+
+from datetime import UTC, datetime, timedelta
+from unittest.mock import patch
+
+import pytest
+from fastmcp import FastMCP
+
+from aden_tools.tools.ssl_tls_scanner import register_tools
+
+
+@pytest.fixture
+def ssl_tools(mcp: FastMCP):
+    """Register SSL tools and return a dict of tool functions."""
+    register_tools(mcp)
+    tools = mcp._tool_manager._tools
+    return {name: tools[name].fn for name in tools}
+
+
+@pytest.fixture
+def scan_fn(ssl_tools):
+    return ssl_tools["ssl_tls_scan"]
+
+
+class TestSSLTLSScan:
+    """Tests for ssl_tls_scan tool."""
+
+    @patch("ssl.create_default_context")
+    @patch("socket.socket")
+    def test_ssl_tls_scan_basic(self, mock_socket, mock_create_context, scan_fn):
+        """Test basic SSL/TLS scan with mock certificate."""
+        mock_context = mock_create_context.return_value
+        mock_sslsock = mock_context.wrap_socket.return_value
+
+        # Mock TLS info
+        mock_sslsock.version.return_value = "TLSv1.3"
+        mock_sslsock.cipher.return_value = ("TLS_AES_256_GCM_SHA384", "TLSv1.3", 256)
+
+        # Mock certificate
+        expiry_date = datetime.now(UTC) + timedelta(days=90)
+        not_after_str = expiry_date.strftime("%b %d %H:%M:%S %Y GMT")
+        not_before_str = (datetime.now(UTC) - timedelta(days=10)).strftime(
+            "%b %d %H:%M:%S %Y GMT"
+        )
+
+        mock_cert = {
+            "subject": ((("commonName", "example.com"),),),
+            "issuer": ((("commonName", "DigiCert Global Root CA"),),),
+            "notBefore": not_before_str,
+            "notAfter": not_after_str,
+            "subjectAltName": (("DNS", "example.com"), ("DNS", "www.example.com")),
+        }
+        mock_sslsock.getpeercert.side_effect = [b"binary-cert-data", mock_cert]
+
+        result = scan_fn(hostname="example.com")
+
+        assert result["hostname"] == "example.com"
+        assert result["tls_version"] == "TLSv1.3"
+        assert result["cipher"] == "TLS_AES_256_GCM_SHA384"
+        assert result["certificate"]["subject"] == "commonName=example.com"
+        assert result["certificate"]["days_until_expiry"] >= 89
+        assert result["grade_input"]["tls_version_ok"] is True
+        assert result["grade_input"]["cert_valid"] is True
+
+    @patch("ssl.create_default_context")
+    @patch("socket.socket")
+    def test_ssl_tls_scan_expired_cert(self, mock_socket, mock_create_context, scan_fn):
+        """Test scan with an expired certificate."""
+        mock_context = mock_create_context.return_value
+        mock_sslsock = mock_context.wrap_socket.return_value
+
+        mock_sslsock.version.return_value = "TLSv1.2"
+        mock_sslsock.cipher.return_value = (
+            "ECDHE-RSA-AES128-GCM-SHA256",
+            "TLSv1.2",
+            128,
+        )
+
+        expired_date = datetime.now(UTC) - timedelta(days=1)
+        not_after_str = expired_date.strftime("%b %d %H:%M:%S %Y GMT")
+
+        mock_cert = {
+            "subject": ((("commonName", "expired.com"),),),
+            "issuer": ((("commonName", "DigiCert"),),),
+            "notAfter": not_after_str,
+        }
+        mock_sslsock.getpeercert.side_effect = [b"data", mock_cert]
+
+        result = scan_fn(hostname="expired.com")
+
+        assert result["grade_input"]["cert_valid"] is False
+        assert any(
+            issue["finding"] == "SSL certificate has expired"
+            for issue in result["issues"]
+        )
+
+    @patch("ssl.create_default_context")
+    @patch("socket.socket")
+    def test_ssl_tls_scan_insecure_version(
+        self, mock_socket, mock_create_context, scan_fn
+    ):
+        """Test scan with insecure TLS version."""
+        mock_context = mock_create_context.return_value
+        mock_sslsock = mock_context.wrap_socket.return_value
+
+        mock_sslsock.version.return_value = "TLSv1.1"
+        mock_sslsock.cipher.return_value = ("AES128-SHA", "TLSv1.1", 128)
+        mock_sslsock.getpeercert.side_effect = [b"data", {}]
+
+        result = scan_fn(hostname="insecure.com")
+
+        assert result["grade_input"]["tls_version_ok"] is False
+        assert any(
+            "Insecure TLS version" in issue["finding"] for issue in result["issues"]
+        )
+
+    @patch("ssl.create_default_context")
+    @patch("socket.socket")
+    def test_ssl_tls_scan_connection_timeout(
+        self, mock_socket, mock_create_context, scan_fn
+    ):
+        """Test scan when connection times out."""
+        mock_socket.return_value.connect.side_effect = TimeoutError()
+
+        # We need to mock the wrap_socket call chain
+        mock_create_context.return_value.wrap_socket.return_value.connect.side_effect = (
+            TimeoutError()
+        )
+
+        result = scan_fn(hostname="timeout.com")
+        assert "error" in result
+        assert "timed out" in result["error"]


### PR DESCRIPTION
Summary
Adds dedicated unit test files for three security-related tools in `aden_tools`:
- `dns_security_scanner`
- `http_headers_scanner`
- `ssl_tls_scanner`

This contributes to issue #5607 by improving test coverage for the tools package.

Validation
Verified locally with `uv run pytest`. All 12 new tests pass.
